### PR TITLE
Update const tracking algorithm and APIs

### DIFF
--- a/test/stablehlo/test_mark_pattern.py
+++ b/test/stablehlo/test_mark_pattern.py
@@ -198,7 +198,7 @@ model_ep = tagging_utils.mark_pattern(
 args = tuple(i.to(xm.xla_device()) for i in args if hasattr(i, "to"))
 res = model_ep(*args)
 
-stablehlo = xm.get_stablehlo([res[0]])
+stablehlo = xm.get_stablehlo([res])
 print(stablehlo)
 
 # stablehlo_bytecode = xm.get_stablehlo_bytecode([res])

--- a/test/stablehlo/test_mark_pattern.py
+++ b/test/stablehlo/test_mark_pattern.py
@@ -170,7 +170,7 @@ from torch_xla.experimental import tagging_utils
 
 #############
 # Pattern to match in the exported graph.
-def log_softmax_pattern(x, dim=1):
+def log_softmax_pattern(x, dim):
     return torch.nn.LogSoftmax(dim=dim)(x)
 
 class M(torch.nn.Module):
@@ -186,12 +186,19 @@ class M(torch.nn.Module):
 m = M().eval()
 args = (torch.rand(200, 200),)
 model_ep = torch.export.export(m, args)
-pattern_args = (torch.rand(200, 200),)
-model_ep = tagging_utils.mark_pattern("softmax_pattern", model_ep, log_softmax_pattern, pattern_args)
+
+model_ep = tagging_utils.mark_pattern(
+    pattern_name="log_softmax_pattern",
+    exported_ep=model_ep,
+    pattern=log_softmax_pattern,
+    pattern_args=(torch.rand(10, 10, 10), 1),
+    const_attr_trackers=[
+        tagging_utils.ConstAttrTracker("dim", pattern_arg_pos=1).track(0).track(1).track(2),
+    ])
 args = tuple(i.to(xm.xla_device()) for i in args if hasattr(i, "to"))
 res = model_ep(*args)
 
-stablehlo = xm.get_stablehlo([res])
+stablehlo = xm.get_stablehlo([res[0]])
 print(stablehlo)
 
 # stablehlo_bytecode = xm.get_stablehlo_bytecode([res])

--- a/torch_xla/experimental/tagging_utils.py
+++ b/torch_xla/experimental/tagging_utils.py
@@ -50,20 +50,23 @@ def select_output(outputs, pos):
     return outputs[pos]
 
 
-def tag_output(x, pos, tag_name, total_output, kwargs):
+def tag_output(x, pos, tag_name, total_output, pattern_attrs=None):
     if tag_name not in tag_output.counter:
         tag_output.counter[tag_name] = 0
+    if pattern_attrs is None:
+        pattern_attrs = {}
+        
     tag_count = tag_output.counter[tag_name]
     match_id = int(tag_count / total_output)
     print(
         "tag_output name: {}, output pos {}, match_id: {}, attr: {}".format(
-            tag_name, pos, match_id, kwargs
+            tag_name, pos, match_id, pattern_attrs
         )
     )
     torch_xla._XLAC._xla_add_tag(
         x,
         json.dumps(
-            PortTag(tag_name, pos, match_id, is_input=False, attr=kwargs),
+            PortTag(tag_name, pos, match_id, is_input=False, attr=pattern_attrs),
             cls=TagSerializer,
         ),
     )
@@ -74,38 +77,37 @@ def tag_output(x, pos, tag_name, total_output, kwargs):
 tag_output.counter = dict()
 
 
-def get_pattern_node(pattern_name, pattern, args, kwargs):
-    pattern_ep = torch.export.export(pattern, args, kwargs)
+def get_pattern_node(pattern_name, pattern, args, pattern_attrs=None):
+    pattern_ep = torch.export.export(pattern, args)
     n_inputs = len(pattern_ep.graph_signature.user_inputs)
     n_outputs = len(pattern_ep.graph_signature.user_outputs)
     print("pattern has {} inputs, {} outputs.".format(n_inputs, n_outputs))
+    
+    if pattern_attrs is None:
+        pattern_attrs = {}
 
     new_g = Graph()
-    placeholders = []
-    # for i in range(n_inputs):
-    # FIXME: try kwargs contain tensor
-    # Skip constant in args and kwargs
-    # currently assume constant is all in kwargs, args only contain tensors
-    n_fx_input = len(args)
-    for i in range(n_fx_input):
-        placeholders.append(new_g.placeholder("input_{}".format(i)))
-
     tagged_placeholders = []
-    # for i in range(n_inputs):
-    for i in range(n_fx_input):
-        tagged_placeholders.append(
-            new_g.call_function(
-                # tag_input, (placeholders[i], i, pattern_name, n_inputs)
-                tag_input,
-                (placeholders[i], i, pattern_name, n_fx_input)
-                # tag_input, (placeholders[i], i, "pattern", n_inputs)
+    n_tensor_inputs = sum(map(torch.is_tensor, args))
+    i = 0
+    for arg in args:
+        if torch.is_tensor(arg):
+            placeholder = new_g.placeholder("input_{}".format(i))
+            tagged_placeholders.append(
+                new_g.call_function(
+                    tag_input,
+                    (placeholder, i, pattern_name, n_tensor_inputs)
+                )
             )
-        )
+            i += 1
+        else:
+            tagged_placeholders.append(arg)
+        
 
     if isinstance(pattern, torch.nn.Module):
         node_tagged = new_g.call_module("pattern")
     else:
-        node_tagged = new_g.call_function(pattern, tuple(tagged_placeholders), kwargs)
+        node_tagged = new_g.call_function(pattern, tuple(tagged_placeholders))
 
     output_nodes = []
     if n_outputs > 1:
@@ -117,7 +119,7 @@ def get_pattern_node(pattern_name, pattern, args, kwargs):
     tagged_output_nodes = []
     for pos, output in enumerate(output_nodes):
         node_tagged_out = new_g.call_function(
-            tag_output, (output, pos, pattern_name, n_outputs, kwargs)
+            tag_output, (output, pos, pattern_name, n_outputs, pattern_attrs)
         )
         tagged_output_nodes.append(node_tagged_out)
 
@@ -127,15 +129,17 @@ def get_pattern_node(pattern_name, pattern, args, kwargs):
 
 
 @dataclass
-class NodeConstantLoc:
-    arg_name: str
+class ConstAttrLoc:
+    attr_name: str
+    pattern_arg_pos: int
     node_name: str
-    pos: int = None
-    key: str = None
+    pos: int
 
 
-def extract_constant_from_matched_pattern(
-    matches: List[subgraph_rewriter.ReplacedPatterns], loc: NodeConstantLoc
+def extract_and_replace_const_from_matched_pattern(
+    pattern,
+    matches: List[subgraph_rewriter.ReplacedPatterns],
+    loc: ConstAttrLoc
 ):
     val = None
     for match in matches:
@@ -143,56 +147,58 @@ def extract_constant_from_matched_pattern(
             if k.name == loc.node_name:
                 # print(str(v.args[loc.pos]))
                 if loc.pos is not None:
-                    val = str(v.args[loc.pos])
+                    val = v.args[loc.pos]
                 # TODO Handel kwarg
         assert val is not None
         for n in match.replacements:
+            if n.op == "call_function" and n.target == pattern:
+                n.update_arg(loc.pattern_arg_pos, val)
             if n.op == "call_function" and n.target == tag_output:
                 attr_arg_idx = 4  # TODO: move to kwarg of the 'tag_ouptut'
                 attr_dict = dict(n.args[attr_arg_idx])
-                attr_dict[loc.arg_name] = val
+                attr_dict[loc.attr_name] = val
                 n.update_arg(4, attr_dict)
 
+@dataclass
+class ConstAttrTracker:
+    attr_name: str
+    pattern_arg_pos: int
+    source_targets: List[Tuple[Any, Any]] = dataclasses.field(default_factory=list)
+    
+    def track(self, source, target=None):
+        if target is None:
+            target = source
+        self.source_targets.append([source, target])
+        return self
+    
+def find_const_attr_loc(pattern, pattern_args, tracker: ConstAttrTracker):
+    const_loc_intersections = None
+    for source, target in tracker.source_targets:
+        track_args = list(pattern_args)
+        track_args[tracker.pattern_arg_pos] = source
+        ep = torch.export.export(pattern, tuple(track_args))
+        
+        const_locs = set()
+        nodes = ep.graph_module.graph.nodes
+        for n in nodes:
+            for arg_pos, arg in enumerate(n.args):
+                if type(arg) == type(target) and arg == target:
+                    const_locs.add((n.name, arg_pos))
+                    
+        if const_loc_intersections is None:
+            const_loc_intersections = const_locs
+        else:
+            const_loc_intersections = const_loc_intersections & const_locs
+        
+        if not const_loc_intersections:
+            break
+            
+    if not const_loc_intersections:
+        return None
+    # Choose any occurrence as the attr provider
+    node_name, arg_pos = const_loc_intersections.pop()
+    return ConstAttrLoc(tracker.attr_name, tracker.pattern_arg_pos, node_name, arg_pos)
 
-def find_constant_arg_mapping(pattern, argsList: List[Tuple], kwargsList:List[Dict]):
-    # Assume const in kwargs
-    print("in find_constant_arg_mapping")
-    assert len(argsList) == 2 and len(kwargsList) == 2 
-    # pos = -1
-    # for idx in range(len(argsList[0])):
-    #     arg0 = argsList[0][idx]
-    #     arg1 = argsList[1][idx]
-    #     assert type(arg0) == type(arg1)
-    #     print(type(arg0))
-    #     if not isinstance(arg0, torch.Tensor):
-    #         # Only caputure the first constant arg
-    #         pos = idx
-    #         break
-    # if pos == -1:
-    #     print("Constant not found")
-    #     return None
-
-    ep1 = torch.export.export(pattern, argsList[0], kwargs=kwargsList[0])
-    ep2 = torch.export.export(pattern, argsList[1], kwargs=kwargsList[1])
-
-    node_list1 = list(ep1.graph_module.graph.nodes)
-    node_list2 = list(ep2.graph_module.graph.nodes)
-    assert len(node_list1) == len(node_list2)
-    # TODO: Extensive check on topological order and op type
-    constant_key = list(kwargsList[0].keys())[0]
-    constant_type = type(kwargsList[0][constant_key])
-    print(constant_type)
-    for idx in range(len(node_list1)):
-        n1_args = node_list1[idx].args
-        n2_args = node_list2[idx].args
-        if len(n1_args) > 0:
-            for arg_idx in range(len(n1_args)):
-                n1_val = n1_args[arg_idx]
-                n2_val = n2_args[arg_idx]
-                print(type(n1_val))
-                if type(n1_val) == constant_type and n1_val != n2_val:
-                    return NodeConstantLoc(constant_key, node_list1[idx].name, pos=arg_idx)
-    return None
 
 def eliminate_dangling_arg(graph: Graph):
     nodes_to_erase = []
@@ -206,28 +212,25 @@ def mark_pattern(
     pattern_name: str,
     exported_ep: GraphModule,
     pattern: Union[Callable, GraphModule, torch.nn.Module],
-    pattern_args: Union[Tuple, List[Tuple]],
-    pattern_kwargs: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
-    constant_fx_node_name: Optional[NodeConstantLoc] = None,
+    # Limit the pattern to not have kwargs
+    pattern_args: Tuple,
+    pattern_attrs: Optional[Dict[str, Any]]=None,
+    const_attr_trackers: Optional[List[Union[ConstAttrLoc, ConstAttrTracker]]]=None,
 ):
     print("check whole graph")
     exported_ep.graph_module.graph.print_tabular()
-    pattern_args_for_export = pattern_args
-    if not isinstance(pattern_args, Tuple):
-        pattern_args_for_export = pattern_args[0]
-    pattern_kwargs_for_export = pattern_kwargs or {}
-    if not isinstance(pattern_kwargs, Dict) and pattern_kwargs is not None:
-        pattern_kwargs_for_export = pattern_kwargs[0]
+    
+    pattern_args = tuple(pattern_args)
 
     if isinstance(pattern, GraphModule):
         pattern_ep = pattern
     else:
         # pattern_ep = torch.export.export(pattern, pattern_args, pattern_kwargs)
         # FIXME: torch.export will generate a dangling input if there is constant
-        pattern_ep = torch.export.export(pattern, pattern_args_for_export, pattern_kwargs_for_export)
+        pattern_ep = torch.export.export(pattern, pattern_args)
     # Build pattern replacement
     replace_pattern_gm = get_pattern_node(
-        pattern_name, pattern, pattern_args_for_export, pattern_kwargs_for_export
+        pattern_name, pattern, pattern_args, pattern_attrs
     )
     print("check replacement gm")
     replace_pattern_gm.graph.print_tabular()
@@ -243,13 +246,17 @@ def mark_pattern(
     )
     print("check matches")
     print(matches)
-    capture_const = (not isinstance(pattern_args, Tuple)) or (constant_fx_node_name is not None)
-    if capture_const:
-        constant_node_mapping = constant_fx_node_name
-        if not isinstance(pattern_args, Tuple):
-            constant_node_mapping = find_constant_arg_mapping(pattern, pattern_args, pattern_kwargs)
-        assert constant_node_mapping is not None
-        print(constant_node_mapping)
-        extract_constant_from_matched_pattern(matches, constant_node_mapping)
+    
+    if const_attr_trackers:
+        for tracker in const_attr_trackers:
+            if isinstance(tracker, ConstAttrLoc):
+                loc = tracker
+            else:
+                loc = find_const_attr_loc(pattern, pattern_args, tracker)
+            
+            assert loc is not None
+            print(loc)
+            extract_and_replace_const_from_matched_pattern(pattern, matches, loc)
+            
     exported_ep.graph_module.graph.print_tabular()
     return exported_ep


### PR DESCRIPTION
- Const tracking algorithm now compares values
  - It is required to have at least a tracker for each const in pattern_args, even if we don't want it to appear in the boundary attr dict. So that the replaced gm can be updated with the new scalar input
  - See implementation for details and specs
- Pattern now cannot take kwargs. All pattern args should be positional.
 